### PR TITLE
cambiado gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 sqlfiles/ACCESO_mysql.sql
+sqlfiles/ACCESO_mysql.json
 Datafiles/
+
 .vs/
 *.suo
 *.sln

--- a/sqlfiles/ACCESO_mysql.json.example
+++ b/sqlfiles/ACCESO_mysql.json.example
@@ -1,0 +1,1 @@
+{"mySQL":{"host":"127.0.0.1","user":"root","password":"clavesecreta"}}


### PR DESCRIPTION
Modificado el .gitignore para que no cargue el fichero con la clave (el fichero se llamaba .json)
Añadido un fichero de ejemplo que debe ser copiado por el usuario:
cp ./sqlfiles/ACCESO_mysql.json.example ./sqlfiles/ACCESO_mysql.json
vi ./sqlfiles/ACCESO_mysql.json